### PR TITLE
Passing express mount path to view

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ app.get('/admin/', greatAdminPanel);
 app.get('/api/', apiHandler);
 
 if (process.env.NODE_ENV !== 'production') {
-  app.use('/api-docs/', ramlStore(path.join(__dirname, 'raml-dir/')));
+  app.use('/api-docs/', ramlStore(path.join(__dirname, 'raml-dir/'), 'api-docs/'));
 }
 
 // continue until...
@@ -41,7 +41,7 @@ var path = require('path');
 var app = require('express');
 var ramlStore = require('express-raml-store');
 
-app.use('/raml-store', ramlStore(path.join(__dirname, 'raml-dir/')));
+app.use('/raml-store/', ramlStore(path.join(__dirname, 'raml-dir/'), 'raml-store/'));
 app.listen(3000);
 ```
 

--- a/dist-override/angular-persistence.js
+++ b/dist-override/angular-persistence.js
@@ -3,6 +3,7 @@
 angular.module('ramlEditorApp')
 .factory('APIStore', function($http, $q, config) {
   var service = {};
+  var base = '/* @echo res */' || '';
 
   function errorFunction(data, status, headers, config) {
     alert(status + ': ' + data);
@@ -12,7 +13,7 @@ angular.module('ramlEditorApp')
     var deferred = $q.defer();
     $http({
       method: 'GET',
-      url: 'files' + path,
+      url: base + 'files' + path,
       withCredentials: false
     }).success(function (data) {
       deferred.resolve(data);
@@ -25,7 +26,7 @@ angular.module('ramlEditorApp')
     var deferred = $q.defer();
     $http({
         method: 'GET',
-        url: 'files' + path,
+        url: base + 'files' + path,
         withCredentials: false,
         transformResponse: function(data) { return data; }
       }).success(function(data) {
@@ -40,7 +41,7 @@ angular.module('ramlEditorApp')
     $http({
       method: 'DELETE',
       data: '',
-      url: 'files' + path,
+      url: base + 'files' + path,
       withCredentials: false
     }).success(function(data) {
       deferred.resolve();
@@ -55,7 +56,7 @@ angular.module('ramlEditorApp')
       data: {
         rename: destination
       },
-      url: 'files' + source,
+      url: base + 'files' + source,
       withCredentials: false
     }).success(function(data) {
       deferred.resolve();
@@ -70,7 +71,7 @@ angular.module('ramlEditorApp')
       data: {
         type: 'folder'
       },
-      url: 'files' + path,
+      url: base + 'files' + path,
       withCredentials: false
     }).success(function(data) {
       deferred.resolve();
@@ -86,7 +87,7 @@ angular.module('ramlEditorApp')
         type: 'file',
         content: contents
       },
-      url: 'files/' + path,
+      url: base + 'files/' + path,
       withCredentials: false
     }).success(function(data) {
       deferred.resolve();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-raml-store",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Express 4 Router to serve mulesoft's api-designer, and save your work on filesystem",
   "author": "mrgamer <mister.gamer@gmail.com",
   "contributors": [
@@ -34,6 +34,7 @@
     "debug": "^2.1.1",
     "express": "4.x",
     "mkdirp": "^0.5.0",
+    "preprocess": "^2.1.1",
     "rimraf": "^2.2.8",
     "sugar": "latest"
   },

--- a/raml-store.js
+++ b/raml-store.js
@@ -14,8 +14,11 @@ function processStatic(mountPath) {
 
     //process angular-persistance.js
     var context = {res: mountPath};
-    fs.mkdirSync(path.join(__dirname, 'dist-override/.tmp')); // may throw
-    pp.preprocessFileSync(path.join(__dirname, 'dist-override/angular-persistence.js'), path.join(__dirname, 'dist-override/.tmp/angular-persistence.js'), context);
+    var tmpPath = path.join(__dirname, 'dist-verride/.tmp');
+    if (!fs.existsSync(tmpPath)) {
+        fs.mkdirSync(tmpPath); // may throw
+    }
+    pp.preprocessFileSync(path.join(__dirname, 'dist-override/angular-persistence.js'), path.join(tmpPath, 'angular-persistence.js'), context);
 }
 
 function serveStatic (req, res, next) {

--- a/raml-store.js
+++ b/raml-store.js
@@ -9,7 +9,7 @@ function processStatic(mountPath) {
     // creates dist-override/index.html
     var indexFile = fs.readFileSync(path.join(__dirname, 'node_modules/api-designer/dist/index.html'), 'utf8');
     indexFile = indexFile.replace(/(href="|src=")(.*")/g, '$1' + mountPath + '$2');  
-    indexFile = indexFile.replace(/<\/body\>/g, '<script src="angular-persistence.js"></script></body>');
+    indexFile = indexFile.replace(/<\/body\>/g, '<script src="' + mountPath + 'angular-persistence.js"></script></body>');
     fs.writeFileSync(path.join(__dirname, 'dist-override/index.html'), indexFile, 'utf8');
 
     //process angular-persistance.js

--- a/raml-store.js
+++ b/raml-store.js
@@ -14,7 +14,7 @@ function processStatic(mountPath) {
 
     //process angular-persistance.js
     var context = {res: mountPath};
-    var tmpPath = path.join(__dirname, 'dist-verride/.tmp');
+    var tmpPath = path.join(__dirname, 'dist-override/.tmp');
     if (!fs.existsSync(tmpPath)) {
         fs.mkdirSync(tmpPath); // may throw
     }

--- a/raml-store.js
+++ b/raml-store.js
@@ -14,7 +14,8 @@ function processStatic(mountPath) {
 
     //process angular-persistance.js
     var context = {res: mountPath};
-    pp.preprocessFileSync(path.join(__dirname, 'dist-override/angular-persistence.js'), path.join(__dirname, '.tmp/dist-override/angular-persistence.js'), context);
+    fs.mkdirSync(path.join(__dirname, 'dist-override/.tmp')); // may throw
+    pp.preprocessFileSync(path.join(__dirname, 'dist-override/angular-persistence.js'), path.join(__dirname, 'dist-override/.tmp/angular-persistence.js'), context);
 }
 
 function serveStatic (req, res, next) {
@@ -22,7 +23,7 @@ function serveStatic (req, res, next) {
     return res.sendFile('/index.html', { root: path.join(__dirname, 'dist-override') });
   }
   if (req.url === '/angular-persistence.js') {
-    return res.sendFile('/angular-persistence.js', { root: path.join(__dirname, 'dist-override') });
+    return res.sendFile('/angular-persistence.js', { root: path.join(__dirname, 'dist-override/.tmp') });
   }
   var requestedFile = req.url.replace(/\?.*/, '');
   debug('requested:', requestedFile);


### PR DESCRIPTION
Corrects the asset paths in index.html and angular-persistance.js to the mount path passed as a 2nd parameter to ramlStore().

Currently, when mounting raml-store under any path other than root '/', as described in the readme ( app.use('/raml-store', ramlStore(...)) ), assets will fail loading. They are hard-coded to root '/'.

Looking forward to feedback! :)
