### PR TITLE
Bump api-designer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "router"
   ],
   "dependencies": {
-    "api-designer": "^0.0.6",
+    "api-designer": "^0.3.2",
     "bluebird": "^2.9.32",
     "body-parser": "^1.13.2",
     "debug": "^2.2.0",


### PR DESCRIPTION
Bumped api-designer version so RAML v1.0 is supported, Issue described in #9